### PR TITLE
Port over the build-tag-release action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # plugin-release-actions
 GitHub actions for standardized releases for WP plugins and Drupal modules
+
+## Build Tag and Release
+This action will build a tag and draft a release for a plugin or module.

--- a/build-tag-release/action.yml
+++ b/build-tag-release/action.yml
@@ -1,0 +1,75 @@
+name: Build, Tag, and Release
+description: Build the assets and push them to a new tag. Create a release based on the tag.
+
+inputs:
+  draft:
+    description: "Create a draft release instead of a regular release."
+    required: false
+    default: "true"
+  build_node_assets:
+    description: "Build the node assets."
+    required: false
+    default: "false"
+  build_composer_assets:
+    description: "Build the composer assets."
+    required: false
+    default: "false"
+  token:
+    description: "The GitHub token to use for authentication."
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup node
+      uses: actions/setup-node@v3
+      with:
+        node-version: "lts"
+        cache: "npm"
+    - name: Build Node Assets
+      if: ${{ inputs.build_node_assets == 'true' }}
+      shell: bash
+      run: |
+        npm ci
+        npm run build
+
+    - name: Build Composer Assets
+      if: ${{ inputs.build_composer_assets == 'true' }}
+      shell: bash
+      run: |
+        composer install --no-dev -o
+
+    - name: Setup
+      shell: bash
+      run: |
+        VERSION=$(cat README.MD| grep 'Stable tag:' | awk '{print $3}')
+        [[ "$VERSION" != "" ]] || exit 1
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+    - name: Commit Assets
+      shell: bash
+      if: ${{ inputs.build_node_assets == 'true' || inputs.build_composer_assets == 'true' }}
+      run: |
+        [[ "$VERSION" != "" ]] || exit 1
+        git config user.name Pantheon Automation
+        git config user.email bot@getpantheon.com
+        git checkout -b "robot-release-$VERSION"
+        [[ ${{ inputs.build_node_assets }} == "true" ]] && git add -f assets/*
+        [[ ${{ inputs.build_composer_assets }} == "true" ]] && git add -f vendor/*
+        git commit -m "Release $VERSION"
+
+    - name: Tag
+      shell: bash
+      run: |
+        echo "Releasing version $VERSION ..."
+        [[ "$VERSION" != "" ]] || exit 1
+        git tag "$VERSION"
+        git push --tags
+
+    - name: Release
+      shell: bash
+      run: |
+        node ../scripts/get_release_notes.js ./README.MD >> ./release_notes.md
+        gh release create $VERSION --title "$VERSION" -F ./release_notes.md $([[ ${{ inputs.draft }} == "true" ]] && echo "--draft")
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}

--- a/build-tag-release/action.yml
+++ b/build-tag-release/action.yml
@@ -14,9 +14,17 @@ inputs:
     description: "Build the composer assets."
     required: false
     default: "false"
-  token:
+  gh_token:
     description: "The GitHub token to use for authentication."
     required: true
+  git_username:
+    description: "The username to use for git commits."
+    required: false
+    default: "Pantheon Automation"
+  git_email:
+    description: "The email to use for git commits."
+    required: false
+    default: "bot@getpantheon.com"
 
 runs:
   using: "composite"
@@ -51,8 +59,8 @@ runs:
       if: ${{ inputs.build_node_assets == 'true' || inputs.build_composer_assets == 'true' }}
       run: |
         [[ "$VERSION" != "" ]] || exit 1
-        git config user.name Pantheon Automation
-        git config user.email bot@getpantheon.com
+        git config user.name "${{ inputs.git_username }}"
+        git config user.email "${{ inputs.git_email }}"
         git checkout -b "robot-release-$VERSION"
         [[ ${{ inputs.build_node_assets }} == "true" ]] && git add -f assets/*
         [[ ${{ inputs.build_composer_assets }} == "true" ]] && git add -f vendor/*
@@ -72,4 +80,4 @@ runs:
         node ../scripts/get_release_notes.js ./README.MD >> ./release_notes.md
         gh release create $VERSION --title "$VERSION" -F ./release_notes.md $([[ ${{ inputs.draft }} == "true" ]] && echo "--draft")
       env:
-        GITHUB_TOKEN: ${{ inputs.token }}
+        GH_TOKEN: ${{ inputs.gh_token }}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "node --test"
   },
   "keywords": [],
+	"type": "module",
   "author": "@pantheon-systems",
   "license": "LGPL-3.0-or-later"
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "plugin-release-actions",
+  "version": "0.1.0",
+	"private": true,
+  "description": "GitHub actions for standardized releases for WP plugins and Drupal modules",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "@pantheon-systems",
+  "license": "LGPL-3.0-or-later"
+}

--- a/scripts/get_release_notes.js
+++ b/scripts/get_release_notes.js
@@ -1,8 +1,10 @@
 "use strict";
-const { readFileSync } = require("fs");
-const { resolve } = require("path");
+import { readFileSync } from "fs";
+import { dirname, resolve } from "path";
 
-module.exports = (() => {
+
+export default (() => {
+  const __dirname = dirname(new URL(import.meta.url).pathname);
   // get the args
   const [path] = process.argv.slice(2);
   // throw if necessary args are missing

--- a/scripts/get_release_notes.js
+++ b/scripts/get_release_notes.js
@@ -1,17 +1,16 @@
 "use strict";
 import { readFileSync } from "fs";
-import { dirname, resolve } from "path";
+import { resolve } from "path";
 
 
 export default (() => {
-  const __dirname = dirname(new URL(import.meta.url).pathname);
   // get the args
   const [path] = process.argv.slice(2);
   // throw if necessary args are missing
   if (!path) {
     throw new Error("Please provide a path to the file to parse");
   }
-  const filePath = resolve(__dirname, "..", path);
+  const filePath = resolve(process.cwd(), path);
   const fileContent = readFileSync(filePath, "utf8");
   /**
    * @see {@link https://regex101.com/r/TmzSYI/1} for the regex explanation

--- a/scripts/get_release_notes.js
+++ b/scripts/get_release_notes.js
@@ -1,0 +1,23 @@
+"use strict";
+const { readFileSync } = require("fs");
+const { resolve } = require("path");
+
+module.exports = (() => {
+  // get the args
+  const [path] = process.argv.slice(2);
+  // throw if necessary args are missing
+  if (!path) {
+    throw new Error("Please provide a path to the file to parse");
+  }
+  const filePath = resolve(__dirname, "..", path);
+  const fileContent = readFileSync(filePath, "utf8");
+  /**
+   * @see {@link https://regex101.com/r/TmzSYI/1} for the regex explanation
+   */
+  const regex =
+    /(^#{3}\s[\s\d\.-\w]+(\([\w\d\s]+\))?$\n(?<notes>^[\w\d\W][^#]{3,}$\n))/gm;
+  const matches = fileContent.matchAll(regex);
+  const [releaseNotes] = [...matches].map((match) => match.groups.notes.trim());
+  console.log(releaseNotes);
+  return releaseNotes;
+})();

--- a/scripts/tests/fixtures/dev.md
+++ b/scripts/tests/fixtures/dev.md
@@ -1,0 +1,24 @@
+# Rossums Universal Robots
+Contributors: [getpantheon](https://profiles.wordpress.org/getpantheon)  
+Donate link: https://example.com/   
+Tags: comments, spam  
+Requires at least: 4.5  
+Tested up to: 6.2.1  
+Requires PHP: 5.6  
+Stable tag: 0.1.2-dev  
+License: GPLv2 or later  
+License URI: https://www.gnu.org/licenses/gpl-2.0.html 
+
+See the robots hard at work.
+
+## Changelog
+
+### 0.1.2-dev
+* Set Counter to 1 [[34](https://github.com/pantheon-systems/plugin-pipeline-example/pull/34)]
+* Set Counter to 2 [[36](https://github.com/pantheon-systems/plugin-pipeline-example/pull/36)]
+
+### 0.1.1 (18 December 2023)
+* Set Counter to 0 [[19](https://github.com/pantheon-systems/plugin-pipeline-example/pull/19)]
+
+### 0.1.0 (6 June 2023)
+* Initial Release [[1](https://github.com/pantheon-systems/plugin-pipeline-example/pull/1)]

--- a/scripts/tests/fixtures/release.md
+++ b/scripts/tests/fixtures/release.md
@@ -1,0 +1,24 @@
+# Rossums Universal Robots
+Contributors: [getpantheon](https://profiles.wordpress.org/getpantheon)  
+Donate link: https://example.com/  
+Tags: comments, spam  
+Requires at least: 4.5  
+Tested up to: 6.2.1  
+Requires PHP: 5.6  
+Stable tag: 0.1.2  
+License: GPLv2 or later  
+License URI: https://www.gnu.org/licenses/gpl-2.0.html 
+
+See the robots hard at work.
+
+## Changelog
+
+### 0.1.2 (19 December 2023)
+* Set Counter to 1 [[34](https://github.com/pantheon-systems/plugin-pipeline-example/pull/34)]
+* Set Counter to 2 [[36](https://github.com/pantheon-systems/plugin-pipeline-example/pull/36)]
+
+### 0.1.1 (18 December 2023)
+* Set Counter to 0 [[19](https://github.com/pantheon-systems/plugin-pipeline-example/pull/19)]
+
+### 0.1.0 (6 June 2023)
+* Initial Release [[1](https://github.com/pantheon-systems/plugin-pipeline-example/pull/1)]

--- a/scripts/tests/get_release_notes.test.js
+++ b/scripts/tests/get_release_notes.test.js
@@ -1,10 +1,11 @@
-const test = require("node:test");
-const assert = require("node:assert");
+"use strict";
+import assert from "node:assert";
+import test from "node:test";
 
 const expected = `* Set Counter to 1 [[34](https://github.com/pantheon-systems/plugin-pipeline-example/pull/34)]
 * Set Counter to 2 [[36](https://github.com/pantheon-systems/plugin-pipeline-example/pull/36)]`;
 
-[
+const cases = [
   {
     name: "dev changelog",
     path: "./scripts/tests/fixtures/dev.md",
@@ -15,10 +16,12 @@ const expected = `* Set Counter to 1 [[34](https://github.com/pantheon-systems/p
     path: "./scripts/tests/fixtures/release.md",
     expected,
   },
-].forEach(({ name, path, expected }) => {
-  test(name, () => {
+];
+
+for await (const { name, path, expected } of cases) {
+  test(name, async () => {
     process.argv[2] = path;
-    const actual = require("../get_release_notes");
+    const actual = (await import("../get_release_notes.js")).default;
     assert.equal(actual, expected);
   });
-});
+}

--- a/scripts/tests/get_release_notes.test.js
+++ b/scripts/tests/get_release_notes.test.js
@@ -1,0 +1,24 @@
+const test = require("node:test");
+const assert = require("node:assert");
+
+const expected = `* Set Counter to 1 [[34](https://github.com/pantheon-systems/plugin-pipeline-example/pull/34)]
+* Set Counter to 2 [[36](https://github.com/pantheon-systems/plugin-pipeline-example/pull/36)]`;
+
+[
+  {
+    name: "dev changelog",
+    path: "./scripts/tests/fixtures/dev.md",
+    expected,
+  },
+  {
+    name: "release changelog",
+    path: "./scripts/tests/fixtures/release.md",
+    expected,
+  },
+].forEach(({ name, path, expected }) => {
+  test(name, () => {
+    process.argv[2] = path;
+    const actual = require("../get_release_notes");
+    assert.equal(actual, expected);
+  });
+});

--- a/scripts/tests/get_release_notes.test.js
+++ b/scripts/tests/get_release_notes.test.js
@@ -18,7 +18,7 @@ const cases = [
   },
 ];
 
-for await (const { name, path, expected } of cases) {
+for (const { name, path, expected } of cases) {
   test(name, async () => {
     process.argv[2] = path;
     const actual = (await import("../get_release_notes.js")).default;


### PR DESCRIPTION
Ports the `build-tag-release` workflow from https://github.com/pantheon-systems/plugin-pipeline-example/blob/main/.github/workflows/build-tag-release.yml#L37 into a composite action.

Added inputs for `build_node_assets`, `build_composer_assets`, `draft`, and `token` for the GITHUB_TOKEN.