### PR TITLE
btr: Skip node setup if no assets

### DIFF
--- a/build-tag-release/action.yml
+++ b/build-tag-release/action.yml
@@ -39,6 +39,7 @@ runs:
   steps:
     - name: Setup node
       uses: actions/setup-node@v3
+      if: ${{ inputs.build_node_assets == 'true' }}
       with:
         node-version: "lts/*"
         cache: "npm"


### PR DESCRIPTION
Fixes setup failing when no node work is called for.

 c/f https://github.com/pantheon-systems/wp-redis/actions/runs/12893555510/job/35950219915