### PR TITLE
[minor] Add prerelease option to the build/tag/release step

### DIFF
--- a/build-tag-release/action.yml
+++ b/build-tag-release/action.yml
@@ -88,7 +88,7 @@ runs:
         [[ "$VERSION" != "" ]] || exit 0
         OLD_VERSION="$VERSION"
         NEW_VERSION="${VERSION}-${GITHUB_SHA::7}"
-        source ${{ github.action_path }}/../scripts/functions.sh
+        source ${{ github.action_path }}/../src/functions.sh
         process_file "${{ inputs.main_plugin_file }}" "$OLD_VERSION" "$NEW_VERSION"
         git add "${{ inputs.main_plugin_file }}"
         echo "VERSION=$NEW_VERSION" >> $GITHUB_ENV

--- a/build-tag-release/action.yml
+++ b/build-tag-release/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: "Create a prerelease instead of a regular release."
     required: false
     default: "false"
+  main_plugin_file:
+    description: "The main plugin file to use for prerelease edits."
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -73,6 +77,22 @@ runs:
         [[ "$VERSION" != "" ]] || exit 1
         echo "VERSION=$VERSION" >> $GITHUB_ENV
 
+    - name: Add prerelease details
+      if: ${{ inputs.prerelease == 'true' }}
+      shell: bash
+      run: |
+        if [[ -z "${{ inputs.main_plugin_file }}" ]]; then
+          echo "No main plugin file specified for prerelease edits."
+          exit 0
+        fi
+        [[ "$VERSION" != "" ]] || exit 0
+        OLD_VERSION="$VERSION"
+        NEW_VERSION="${VERSION}-${GITHUB_SHA::7}"
+        source ${{ github.action_path }}/../scripts/functions.sh
+        process_file "${{ inputs.main_plugin_file }}" "$OLD_VERSION" "$NEW_VERSION"
+        git add "${{ inputs.main_plugin_file }}"
+        echo "VERSION=$NEW_VERSION" >> $GITHUB_ENV
+
     - name: Commit Assets
       shell: bash
       if: ${{ inputs.build_node_assets == 'true' || inputs.build_composer_assets == 'true' }}
@@ -84,6 +104,7 @@ runs:
         [[ ${{ inputs.build_node_assets }} == "true" ]] && git add -f assets/*
         [[ ${{ inputs.build_composer_assets }} == "true" ]] && git add -f vendor/*
         git commit -m "Release $VERSION"
+
 
     - name: Tag
       shell: bash

--- a/build-tag-release/action.yml
+++ b/build-tag-release/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: "Use GitHub's generated release notes"
     required: false
     default: false
+  prerelease:
+    description: "Create a prerelease instead of a regular release."
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -96,7 +100,7 @@ runs:
       shell: bash
       run: |
         node ${{ github.action_path }}/../scripts/get_release_notes.js ./${{ inputs.readme_md }} >> ./release_notes.md
-        gh release create $VERSION --title "$VERSION" -F ./release_notes.md $([[ ${{ inputs.draft }} == "true" ]] && echo "--draft")
+        gh release create $VERSION --title "$VERSION" -F ./release_notes.md $([[ ${{ inputs.draft }} == "true" ]] && echo "--draft")  $([[ ${{ inputs.prerelease }} == "true" ]] && echo "--prerelease")
       env:
         GH_TOKEN: ${{ inputs.gh_token }}
 
@@ -104,6 +108,6 @@ runs:
       if: ${{ inputs.generate_release_notes == 'true' }}
       shell: bash
       run: |
-        gh release create $VERSION --title "$VERSION" --generate-notes --verify-tag $([[ ${{ inputs.draft }} == "true" ]] && echo "--draft")
+        gh release create $VERSION --title "$VERSION" --generate-notes --verify-tag $([[ ${{ inputs.draft }} == "true" ]] && echo "--draft") $([[ ${{ inputs.prerelease }} == "true" ]] && echo "--prerelease")
       env:
         GH_TOKEN: ${{ inputs.gh_token }}

--- a/build-tag-release/action.yml
+++ b/build-tag-release/action.yml
@@ -83,7 +83,7 @@ runs:
       run: |
         if [[ -z "${{ inputs.main_plugin_file }}" ]]; then
           echo "No main plugin file specified for prerelease edits."
-          exit 0
+          exit 1
         fi
         [[ "$VERSION" != "" ]] || exit 0
         OLD_VERSION="$VERSION"


### PR DESCRIPTION
New flag gives the option for publishing a pre-release instead. Requires a target file for the additional search-replace as well.