### PR TITLE
feat: Add validate-fixture-version action

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,6 @@ test-node:
 test: test-node
 
 lint-shell:
-	shellcheck prepare-dev/*.sh src/*.sh release-pr/*.sh
+	shellcheck prepare-dev/*.sh src/*.sh release-pr/*.sh validate-fixture-version/*.sh
 
 lint: lint-shell

--- a/README.md
+++ b/README.md
@@ -55,5 +55,25 @@ This action will draft a "ship it" PR to the `release` branch when new features 
 
 This action expects to make use of the label "automation" on the repo. Create it if it does not already exist.
 
+### Validate Fixture Version
+
+This action validates that the plugin's `readme.txt` `Tested up to:` field matches the current WordPress version published on WP.org, as well as the WordPress version running on a Pantheon Terminus `.dev` fixture environment. If the fixture is behind the current WordPress version, the action applies upstream updates automatically before validating.
+
+```yaml
+- name: Validate Fixture Version
+  uses: pantheon-systems/plugin-release-actions/validate-fixture-version@main
+  with:
+    terminus_token: ${{ secrets.TERMINUS_MACHINE_TOKEN }}
+    terminus_site: my-pantheon-site
+```
+
+#### Inputs
+
+| Name | Description | Required | Default |
+| --- | --- | --- | --- |
+| `terminus_token` | Pantheon machine token for Terminus authentication. Not required if Terminus is already authenticated in a prior step. | No | |
+| `terminus_site` | The Pantheon site machine name to use as the WordPress fixture environment. | Yes | |
+| `readme_txt` | Path to the plugin's `readme.txt`, relative to the repository root. | No | `readme.txt` |
+
 ## Merging Commits
 _TBD explain why features should be squashed and releases must be merged._

--- a/validate-fixture-version/action.yml
+++ b/validate-fixture-version/action.yml
@@ -1,0 +1,29 @@
+name: Validate Fixture Version
+description: >
+  Validates that the plugin's readme.txt "Tested up to:" field matches
+  the current WordPress version and the version running on a Pantheon
+  Terminus dev fixture environment.
+
+inputs:
+  terminus_token:
+    description: "Pantheon machine token for Terminus authentication. Not required if Terminus is already authenticated."
+    required: false
+    default: ""
+  terminus_site:
+    description: "The Pantheon site machine name to use as the WordPress fixture environment."
+    required: true
+  readme_txt:
+    description: "Path to the plugin's readme.txt file, relative to the repository root."
+    required: false
+    default: "readme.txt"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate Fixture Version
+      shell: bash
+      run: bash ${{ github.action_path }}/validate-fixture-version.sh
+      env:
+        TERMINUS_TOKEN: ${{ inputs.terminus_token }}
+        TERMINUS_SITE: ${{ inputs.terminus_site }}
+        README_TXT: ${{ inputs.readme_txt }}

--- a/validate-fixture-version/action.yml
+++ b/validate-fixture-version/action.yml
@@ -22,8 +22,9 @@ runs:
   steps:
     - name: Validate Fixture Version
       shell: bash
-      run: bash ${{ github.action_path }}/validate-fixture-version.sh
+      run: bash "$ACTION_PATH/validate-fixture-version.sh"
       env:
+        ACTION_PATH: ${{ github.action_path }}
         TERMINUS_TOKEN: ${{ inputs.terminus_token }}
         TERMINUS_SITE: ${{ inputs.terminus_site }}
         README_TXT: ${{ inputs.readme_txt }}

--- a/validate-fixture-version/validate-fixture-version.sh
+++ b/validate-fixture-version/validate-fixture-version.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+main() {
+    export TERMINUS_HIDE_GIT_MODE_WARNING=1
+
+    if [[ -z "${TERMINUS_SITE:-}" ]]; then
+        echo "TERMINUS_SITE environment variable must be set"
+        exit 1
+    fi
+
+    if ! terminus whoami > /dev/null 2>&1; then
+        if [[ -z "${TERMINUS_TOKEN:-}" ]]; then
+            echo "TERMINUS_TOKEN environment variable must be set or terminus already logged in."
+            exit 1
+        fi
+        terminus auth:login --machine-token="${TERMINUS_TOKEN}"
+    fi
+
+    local CURRENT_WP_VERSION
+    CURRENT_WP_VERSION=$(curl -s https://api.wordpress.org/core/version-check/1.7/ | jq -r '.offers[0].current')
+    echo "Current WordPress Version: ${CURRENT_WP_VERSION}"
+
+    local README_FILE_PATH="${README_TXT:-readme.txt}"
+    if [[ ! -f "${README_FILE_PATH}" ]]; then
+        echo "readme.txt not found at: ${README_FILE_PATH}"
+        exit 1
+    fi
+
+    local TESTED_UP_TO
+    TESTED_UP_TO=$(grep -i "Tested up to:" "${README_FILE_PATH}" | tr -d '\r\n' | awk -F ': ' '{ print $2 }')
+    echo "Tested Up To: ${TESTED_UP_TO}"
+
+    local FIXTURE_VERSION
+    FIXTURE_VERSION=$(terminus wp "${TERMINUS_SITE}.dev" -- core version)
+    echo "Fixture Version: ${FIXTURE_VERSION}"
+
+    local FIXTURE_VERSION_COMPARE
+    FIXTURE_VERSION_COMPARE=$(php -r "echo version_compare('${FIXTURE_VERSION}', '${CURRENT_WP_VERSION}');")
+    if [[ "${FIXTURE_VERSION_COMPARE}" == "-1" ]]; then
+        echo "Fixture Version: ${FIXTURE_VERSION} is less than Current WordPress Version: ${CURRENT_WP_VERSION}"
+        echo "Applying upstream updates on ${TERMINUS_SITE}"
+        terminus upstream:updates:apply --site="${TERMINUS_SITE}" --env=dev --accept-upstream --updatedb
+    fi
+
+    local WP_VERSION_COMPARE
+    WP_VERSION_COMPARE=$(php -r "echo version_compare('${TESTED_UP_TO}', '${CURRENT_WP_VERSION}');")
+
+    if [[ "${WP_VERSION_COMPARE}" == "0" ]]; then
+        echo "Tested Up To: ${TESTED_UP_TO} matches Current WordPress Version: ${CURRENT_WP_VERSION}"
+    elif [[ "${WP_VERSION_COMPARE}" == "1" ]]; then
+        echo "Tested Up To: ${TESTED_UP_TO} is greater than Current WordPress Version: ${CURRENT_WP_VERSION}"
+    else
+        echo "Tested Up To: ${TESTED_UP_TO} does not match Current WordPress Version: ${CURRENT_WP_VERSION}"
+        echo "Please update ${TESTED_UP_TO} to ${CURRENT_WP_VERSION}"
+        exit 1
+    fi
+
+    local VERSION_COMPARE
+    VERSION_COMPARE=$(php -r "echo version_compare('${TESTED_UP_TO}', '${FIXTURE_VERSION}');")
+
+    if [[ "${VERSION_COMPARE}" == "0" ]]; then
+        echo "Tested Up To: ${TESTED_UP_TO} matches Fixture Version: ${FIXTURE_VERSION}"
+        exit 0
+    fi
+
+    if [[ "${VERSION_COMPARE}" == "-1" ]]; then
+        echo "${TESTED_UP_TO} is less than ${FIXTURE_VERSION}"
+        echo "Please update ${TESTED_UP_TO} to ${FIXTURE_VERSION}"
+        exit 1
+    fi
+
+    if [[ "${VERSION_COMPARE}" == "1" ]]; then
+        echo "${FIXTURE_VERSION} is less than ${TESTED_UP_TO}"
+
+        local CURRENT_MAJOR CURRENT_MINOR
+        read -r CURRENT_MAJOR CURRENT_MINOR <<<"$(echo "${CURRENT_WP_VERSION}" | awk -F. '{print $1, $2}')"
+        local NEXT_MAJOR_VERSION="${CURRENT_MAJOR}.$((CURRENT_MINOR + 1))"
+
+        if [[ "${TESTED_UP_TO}" == "${NEXT_MAJOR_VERSION}" ]]; then
+            echo "Tested Up To: ${TESTED_UP_TO} is the next major version after the Current WordPress Version: ${CURRENT_WP_VERSION}"
+            echo "Ensure you have validated that the plugin works on the next major version of WordPress or update ${TERMINUS_SITE} to a pre-release version."
+        else
+            echo "Tested Up To: ${TESTED_UP_TO} is not the next major version (${NEXT_MAJOR_VERSION}). This seems like an error. Please review."
+            exit 1
+        fi
+    fi
+}
+
+main


### PR DESCRIPTION
## Summary

- Adds a new `validate-fixture-version` composite GitHub Action wrapping the `validate-fixture-version.sh` script
- Validates that a plugin's `readme.txt` `Tested up to:` field matches the current WordPress version (from WP.org API) and the version on a Pantheon Terminus `.dev` fixture environment
- Automatically applies upstream updates via Terminus if the fixture is behind the current WP version
- Adds the new script to the `shellcheck` lint target in the Makefile
- Documents the new action in README.md

## Key improvements over the original gist

- Replaces `dirname "$0"` + `find` with a `readme_txt` input (passed as `README_TXT` env var) — `$0` is unreliable in composite actions
- Fixes shellcheck SC2046: quotes the here-string subshell (`<<<"$()"`)
- Uses `${VAR:-}` guards for optional vars to avoid `set -u` failures
- Adds `--site`, `--env=dev`, `--accept-upstream`, `--updatedb` to `terminus upstream:updates:apply` for non-interactive CI use
- Wires inputs via `env:` on the action step to avoid shell injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)