### PR TITLE
fix: Compare Tested Up To without patch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This action expects to make use of the label "automation" on the repo. Create it
 
 ### Validate Fixture Version
 
-This action validates that the plugin's `readme.txt` `Tested up to:` field matches the current WordPress version published on WP.org, as well as the WordPress version running on a Pantheon Terminus `.dev` fixture environment. If the fixture is behind the current WordPress version, the action applies upstream updates automatically before validating.
+This action validates that the plugin's `readme.txt` `Tested up to:` field matches the current WordPress version published on WP.org, as well as the WordPress version running on a Pantheon Terminus `.dev` fixture environment. Patch versions are ignored during comparison (e.g. `Tested up to: 6.9` will match WP `6.9.4`). If the fixture is behind the current WordPress version, the action applies upstream updates automatically before validating.
 
 ```yaml
 - name: Validate Fixture Version

--- a/validate-fixture-version/action.yml
+++ b/validate-fixture-version/action.yml
@@ -1,8 +1,8 @@
 name: Validate Fixture Version
 description: >
   Validates that the plugin's readme.txt "Tested up to:" field matches
-  the current WordPress version and the version running on a Pantheon
-  Terminus dev fixture environment.
+  the current WordPress version (comparing without patch version) and the
+  version running on a Pantheon Terminus dev fixture environment.
 
 inputs:
   terminus_token:

--- a/validate-fixture-version/validate-fixture-version.sh
+++ b/validate-fixture-version/validate-fixture-version.sh
@@ -2,6 +2,10 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+trim_patch_version() {
+    echo "$1" | awk -F. '{print $1"."$2}'
+}
+
 main() {
     export TERMINUS_HIDE_GIT_MODE_WARNING=1
 
@@ -44,35 +48,40 @@ main() {
         terminus upstream:updates:apply --site="${TERMINUS_SITE}" --env=dev --accept-upstream --updatedb
     fi
 
+    local CURRENT_WP_VERSION_TRIMMED
+    CURRENT_WP_VERSION_TRIMMED=$(trim_patch_version "${CURRENT_WP_VERSION}")
+    local FIXTURE_VERSION_TRIMMED
+    FIXTURE_VERSION_TRIMMED=$(trim_patch_version "${FIXTURE_VERSION}")
+
     local WP_VERSION_COMPARE
-    WP_VERSION_COMPARE=$(php -r "echo version_compare('${TESTED_UP_TO}', '${CURRENT_WP_VERSION}');")
+    WP_VERSION_COMPARE=$(php -r "echo version_compare('${TESTED_UP_TO}', '${CURRENT_WP_VERSION_TRIMMED}');")
 
     if [[ "${WP_VERSION_COMPARE}" == "0" ]]; then
-        echo "Tested Up To: ${TESTED_UP_TO} matches Current WordPress Version: ${CURRENT_WP_VERSION}"
+        echo "Tested Up To: ${TESTED_UP_TO} matches Current WordPress Version: ${CURRENT_WP_VERSION} (trimmed: ${CURRENT_WP_VERSION_TRIMMED})"
     elif [[ "${WP_VERSION_COMPARE}" == "1" ]]; then
         echo "Tested Up To: ${TESTED_UP_TO} is greater than Current WordPress Version: ${CURRENT_WP_VERSION}"
     else
-        echo "Tested Up To: ${TESTED_UP_TO} does not match Current WordPress Version: ${CURRENT_WP_VERSION}"
-        echo "Please update ${TESTED_UP_TO} to ${CURRENT_WP_VERSION}"
+        echo "Tested Up To: ${TESTED_UP_TO} does not match Current WordPress Version: ${CURRENT_WP_VERSION} (trimmed: ${CURRENT_WP_VERSION_TRIMMED})"
+        echo "Please update ${TESTED_UP_TO} to ${CURRENT_WP_VERSION_TRIMMED}"
         exit 1
     fi
 
     local VERSION_COMPARE
-    VERSION_COMPARE=$(php -r "echo version_compare('${TESTED_UP_TO}', '${FIXTURE_VERSION}');")
+    VERSION_COMPARE=$(php -r "echo version_compare('${TESTED_UP_TO}', '${FIXTURE_VERSION_TRIMMED}');")
 
     if [[ "${VERSION_COMPARE}" == "0" ]]; then
-        echo "Tested Up To: ${TESTED_UP_TO} matches Fixture Version: ${FIXTURE_VERSION}"
+        echo "Tested Up To: ${TESTED_UP_TO} matches Fixture Version: ${FIXTURE_VERSION} (trimmed: ${FIXTURE_VERSION_TRIMMED})"
         exit 0
     fi
 
     if [[ "${VERSION_COMPARE}" == "-1" ]]; then
-        echo "${TESTED_UP_TO} is less than ${FIXTURE_VERSION}"
-        echo "Please update ${TESTED_UP_TO} to ${FIXTURE_VERSION}"
+        echo "${TESTED_UP_TO} is less than ${FIXTURE_VERSION} (trimmed: ${FIXTURE_VERSION_TRIMMED})"
+        echo "Please update ${TESTED_UP_TO} to ${FIXTURE_VERSION_TRIMMED}"
         exit 1
     fi
 
     if [[ "${VERSION_COMPARE}" == "1" ]]; then
-        echo "${FIXTURE_VERSION} is less than ${TESTED_UP_TO}"
+        echo "${FIXTURE_VERSION} (trimmed: ${FIXTURE_VERSION_TRIMMED}) is less than ${TESTED_UP_TO}"
 
         local CURRENT_MAJOR CURRENT_MINOR
         read -r CURRENT_MAJOR CURRENT_MINOR <<<"$(echo "${CURRENT_WP_VERSION}" | awk -F. '{print $1, $2}')"


### PR DESCRIPTION
## Summary

- Trim patch version from WordPress current version and fixture version before comparing to `Tested up to` field
- Fixes false failures when `Tested up to: 6.9` is compared against WP `6.9.4`

## Context

The `Tested up to` field in `readme.txt` follows WordPress convention of omitting the patch version (e.g. `6.9`). The WordPress API and Pantheon fixture sites return full versions including patch (e.g. `6.9.4`). PHP `version_compare('6.9', '6.9.4')` returns `-1` (less than), causing the validation to fail incorrectly.

This affects all plugins using this shared action when WordPress releases a patch version after the plugin's `Tested up to` was set.

The fixture upgrade check (whether the fixture needs upstream updates) still compares full versions, since that check is about actual WordPress versions, not the `Tested up to` convention.
