### PR TITLE
[SITE-5785] Use github-actions[bot] identity for verified commits

### DIFF
--- a/build-tag-release/action.yml
+++ b/build-tag-release/action.yml
@@ -20,11 +20,11 @@ inputs:
   git_username:
     description: "The username to use for git commits."
     required: false
-    default: "Pantheon Automation"
+    default: "github-actions[bot]"
   git_email:
     description: "The email to use for git commits."
     required: false
-    default: "bot@getpantheon.com"
+    default: "41898282+github-actions[bot]@users.noreply.github.com"
   readme_md:
     description: "The readme file name"
     required: false

--- a/prepare-dev/prepare-dev.sh
+++ b/prepare-dev/prepare-dev.sh
@@ -11,9 +11,9 @@ readonly SELF_DIRNAME="$(dirname -- "$0")"
 
 # TODO: Parameterize or make case-insensitive when this is an action
 # shellcheck disable=SC2034
-readonly GIT_USER="bot@getpantheon.com"
+readonly GIT_USER="41898282+github-actions[bot]@users.noreply.github.com"
 # shellcheck disable=SC2034
-readonly GIT_NAME="Pantheon Automation"
+readonly GIT_NAME="github-actions[bot]"
 
 # shellcheck disable=SC1091
 source "${SELF_DIRNAME}/../src/functions.sh"

--- a/release-pr/release-pr.sh
+++ b/release-pr/release-pr.sh
@@ -7,9 +7,9 @@ readonly SELF_DIRNAME="$(dirname -- "$0")"
 
 # TODO: Parameterize or make case-insensitive when this is an action
 # shellcheck disable=SC2034
-readonly GIT_USER="bot@getpantheon.com"
+readonly GIT_USER="41898282+github-actions[bot]@users.noreply.github.com"
 # shellcheck disable=SC2034
-readonly GIT_NAME="Pantheon Automation"
+readonly GIT_NAME="github-actions[bot]"
 
 # shellcheck disable=SC1091
 source "${SELF_DIRNAME}/../src/functions.sh"


### PR DESCRIPTION
## Summary

Org-level rulesets now require verified (signed) commits on all SiteX repos. 

The previous identity (`bot@getpantheon.com` / "Pantheon Automation") produces unsigned commits that will be blocked by branch protection.

Commits made by GitHub Actions workflows are auto-signed by GitHub when they use the `github-actions[bot]` noreply email (`41898282+github-actions[bot]@users.noreply.github.com`). 

This PR updates the git identity in all three places where it's hardcoded:

- `prepare-dev/prepare-dev.sh` (prepares next dev version after release)
- `release-pr/release-pr.sh` (creates release PRs)
- `build-tag-release/action.yml` (input defaults for build-tag-release action)

Affects all WP plugin repos that consume these actions: pantheon-advanced-page-cache, wp-native-php-sessions, wp-redis, pantheon-hud, pantheon-content-publisher-wordpress, wp-saml-auth.

## Verification

These actions run during actual plugin releases, so verification happens on the next natural release of any consuming repo:

- [ ] After merging, on the next plugin release: verify the release-pr commit shows as "Verified" on GitHub
- [ ] Verify the prepare-dev commit shows as "Verified"
- [ ] Verify the build-tag-release commit shows as "Verified"

No way to test in isolation without triggering full release workflows on a real repo, which is disproportionate for a string substitution. The mechanism (GitHub auto-signing commits from the `github-actions[bot]` noreply email) is documented GitHub behavior.

Related: [SITE-5785](https://getpantheon.atlassian.net/browse/SITE-5785)

[SITE-5785]: https://getpantheon.atlassian.net/browse/SITE-5785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ